### PR TITLE
fix: center FirstLaunchView window and fix countdown timer

### DIFF
--- a/Source/Extensions/View+OpenWindow.swift
+++ b/Source/Extensions/View+OpenWindow.swift
@@ -29,22 +29,29 @@ extension View {
         // Create a new window with the hosting controller as its content.
         let controller = NSHostingController(rootView: self)
         let window = NSWindow(contentViewController: controller)
-        
+
         // Define the window's style, making it closable and titled.
         window.styleMask = [.closable, .titled]
-        
+
         // Set the hosting controller as the window's content view controller.
         window.contentViewController = controller
-        
+
         // Set the window's title.
         window.title = title
-        
+
         // Ensure the window's resources are released when it's closed.
         window.isReleasedWhenClosed = true
-        
+
+        // Force layout to calculate SwiftUI content size before centering.
+        controller.view.layoutSubtreeIfNeeded()
+        window.setContentSize(controller.view.fittingSize)
+
+        // Center the window on screen.
+        window.center()
+
         // Bring the window to the front and activate it.
         window.makeKeyAndOrderFront(sender)
-        
+
         return window
     }
 }

--- a/Source/Models/AppSettings.swift
+++ b/Source/Models/AppSettings.swift
@@ -52,7 +52,7 @@ struct OptionsSettings: Codable, Equatable {
     /// Flag to indicate if the application settings/data is protected.
     var isProtected: Bool = false
     var authSettings: AuthSettings = .init()
-    }
+}
 
 struct AuthSettings: Codable, Equatable {
     var biometrics = false
@@ -66,7 +66,7 @@ struct AuthSettings: Codable, Equatable {
     static var empty: Self {
         .init()
     }
-    }
+}
 
 /// Represents the triggers for capturing snapshots based on various events.
 ///
@@ -116,25 +116,25 @@ struct SyncSettings: Codable, Equatable {
 protocol AppSettingsProtocol {
     /// Flag to indicate if the app is built for Mac App Store.
     static var isMASBuild: Bool { get }
-
+    
     /// Flag to enable/disable image capture debugging.
     static var isImageCaptureDebug: Bool { get }
-
+    
     /// The count of successful launches to determine if it's the app's first launch.
     static var firstLaunchSuccessCount: Int { get }
-
+    
     /// Options/settings related to the application's behavior.
     var options: OptionsSettings { get set }
-
+    
     /// Settings to determine when snapshots should be captured.
     var triggers: TriggerSettings { get set }
-
+    
     /// Settings related to synchronization and storage of snapshots.
     var sync: SyncSettings { get set }
-
+    
     /// Settings to manage and store the state of user interface elements.
     var ui: UISettings { get set }
-
+    
     /// Resets all settings to their default values.
     func resetToDefaults()
 }
@@ -168,7 +168,7 @@ final class AppSettings: AppSettingsProtocol {
     /// UI settings to remember the state of user interface elements.
     @UserDefault("UISettings", defaultValue: UISettings())
     var ui: UISettings
-
+    
     /// Resets all settings to their default values.
     func resetToDefaults() {
         options = OptionsSettings()
@@ -182,19 +182,19 @@ final class AppSettings: AppSettingsProtocol {
 ///
 final class AppSettingsPreview: AppSettingsProtocol {
     static let isMASBuild: Bool = true
-
+    
     static let isImageCaptureDebug: Bool = true
-
+    
     static let firstLaunchSuccessCount: Int = 15
-
+    
     var options: OptionsSettings = .init()
-
+    
     var triggers: TriggerSettings = .init()
-
+    
     var sync: SyncSettings = .init()
-
+    
     var ui: UISettings = .init()
-
+    
     func resetToDefaults() {
         options = OptionsSettings()
         triggers = TriggerSettings()

--- a/Source/Views/FirstLaunch/Subviews/FirstLaunchSuccessView.swift
+++ b/Source/Views/FirstLaunch/Subviews/FirstLaunchSuccessView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 /// A SwiftUI view that presents a success message and visuals to the user when the initial setup completes successfully.
 struct FirstLaunchSuccessView: View {
-    /// A binding to the count-down timer value that informs the user about the time left before proceeding.
-    @State var successCountDown: Int
+    /// The count-down timer value that informs the user about the time left before proceeding.
+    let successCountDown: Int
 
     /// The frame size for adjusting visual elements within this view.
-    @State var frameSize: CGSize
+    let frameSize: CGSize
 
     /// The body property that returns the content of the view.
     var body: some View {


### PR DESCRIPTION
## Summary
- Force NSHostingController layout before centering to ensure correct window size calculation
- Changed successCountDown from @State to let to properly propagate parent viewmodel updates
- Countdown timer now correctly decrements and displays before window closes
- Minor formatting fixes (whitespace/indentation)

## Test plan
- Launch app for first time to trigger FirstLaunchView
- Verify window appears centered on screen
- Verify countdown timer updates every second and closes window after completion